### PR TITLE
#47 autoindex parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@ SRCS   	= \
         $(SRCS_DIR)/ConfigParser.cpp \
         $(SRCS_DIR)/ConfigDispatcher.cpp \
         $(SRCS_DIR)/Utils.cpp \
-
+		$(SRCS_DIR)/main_config.cpp
 TESTS	= \
+		
 
 OBJS		= $(SRCS:${SRCS_DIR}/%.cpp=${OBJS_DIR}/%.o)
 TEST_OBJS	= $(TESTS:${TEST_DIR}/%.cpp=${TEST_OBJS_DIR}/%.o)

--- a/config_files/webserv.conf
+++ b/config_files/webserv.conf
@@ -44,7 +44,8 @@ webserv
     server
     {
         host                        2.2.2.2;
-        port                        69;                            
+        port                        69;
+        autoindex                   enabled;                               
         server_name                 yourmumshouse.com;
         access_log                  logs/domain3.access.log;
         client_max_body_size        1M;                                
@@ -66,6 +67,7 @@ webserv
                 extension           .py;
                 handler             /usr/bin/python3;
                 allowed_methods     GET POST;
+                autoindex           enabled;
             }
             bash
             {

--- a/inc/LocationInfo.hpp
+++ b/inc/LocationInfo.hpp
@@ -11,8 +11,8 @@ class LocationInfo
 									~LocationInfo();
 									LocationInfo(const LocationInfo& rhs);
 		LocationInfo&				operator=(const LocationInfo& rhs);
-		bool						getAutoindex() const;
-		void						setAutoindex(bool b);
+		bool						autoindex_enabled() const;
+		void						set_autoindex(const std::vector <std::string>& autoindex);
 		std::string					get_root() const;
 		void						set_root(const std::vector <std::string>& root);
 		std::vector <std::string>	get_allowed_methods() const;

--- a/inc/LocationInfo.hpp
+++ b/inc/LocationInfo.hpp
@@ -13,15 +13,14 @@ class LocationInfo
 		LocationInfo&				operator=(const LocationInfo& rhs);
 		bool						getAutoindex() const;
 		void						setAutoindex(bool b);
-		std::string					getPath() const;
+		std::string					get_root() const;
 		void						set_root(const std::vector <std::string>& root);
 		std::vector <std::string>	get_allowed_methods() const;
 		void						set_allowed_methods(const std::vector <std::string>& allowed_methods);
+		std::string					get_path() const;
+		void						set_path(const std::string& name);
 		bool						directory_listing_enabled() const;
-		void						set_directory_listing(bool directory_listing_enabled);
-
 		void						set_directory_listing(const std::vector <std::string>& directory_listing_enabled);
-		std::string					get_name() const;
 		void						set_return(const std::vector <std::string>& r);
 		std::string					get_return() const;
 		void						set_alias(const std::vector <std::string>& a);
@@ -30,7 +29,6 @@ class LocationInfo
 		std::string					get_cgi_path() const;
 		void						set_cgi_extension(const std::vector <std::string>& e);
 		std::string					get_cgi_extension() const;
-		void						set_name(const std::string& name);
 		int							get_client_max_body_size() const;
 		void						set_client_max_body_size(int n);
 		bool						is_cgi() const;

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -407,6 +407,7 @@ void	Config::initialize_location_setters()
 	_location_setters["alias"] = &LocationInfo::set_alias;
 	_location_setters["handler"] = &LocationInfo::set_cgi_path;
 	_location_setters["extension"] = &LocationInfo::set_cgi_extension;
+	_location_setters["autoindex"] = &LocationInfo::set_autoindex;
 }
 
 Config::~Config() 
@@ -458,6 +459,14 @@ std::ostream &operator<<(std::ostream &out, const Config &config)
 			else
 			{
 				std::cout << "\t\tdirectory listing: disabled" << std::endl;
+			}
+			if ((*it)->autoindex_enabled() == true)
+			{
+				std::cout << "\t\tautoindex: enabled" << std::endl;
+			}
+			else
+			{
+				std::cout << "\t\tautoindex: disabled" << std::endl;
 			}
 			std::cout << "\t\tallowed_methods: ";
 			std::vector <std::string> allowed_methods = (*it)->get_allowed_methods();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -126,7 +126,7 @@ std::string	Config::extract_location_name(const std::string& current_map_key)
 //	->	return the setter for the current map key
 Config::location_setter_map::iterator	Config::initialize_location(const std::string& name, const std::string& key, LocationInfo*& new_location)
 {
-	if (new_location == NULL || name != new_location->get_name())
+	if (new_location == NULL || name != new_location->get_path())
 	{
 		if (name != "/cgi-bin")
 		{
@@ -135,7 +135,7 @@ Config::location_setter_map::iterator	Config::initialize_location(const std::str
 				_locations.push_back(new_location);
 			}
 			new_location = new LocationInfo;
-			new_location->set_name(name);
+			new_location->set_path(name);
 		}
 		else 
 		{
@@ -210,7 +210,7 @@ Config::location_setter_map::iterator	Config::configure_cgi(std::string key, Loc
 
 	if (new_location != NULL)
 	{
-		if (cgi_name != new_location->get_name())
+		if (cgi_name != new_location->get_path())
 		{
 			_locations.push_back(new_location);
 			new_location = new LocationInfo;
@@ -220,7 +220,7 @@ Config::location_setter_map::iterator	Config::configure_cgi(std::string key, Loc
 	{
 		new_location = new LocationInfo;
 	}
-	new_location->set_name(cgi_name);
+	new_location->set_path(cgi_name);
 	new_location->set_is_cgi(true);
 
 	std::string current_key = key.substr(key.find_last_of(":") + 1);
@@ -449,8 +449,8 @@ std::ostream &operator<<(std::ostream &out, const Config &config)
 		std::vector <LocationInfo *> locations = (*it)->get_locations();
 		for (std::vector <LocationInfo *>::iterator it = locations.begin(); it != locations.end(); it++)
 		{
-			std::cout << "\tname: " << (*it)->get_name() << std::endl;
-			std::cout << "\t\troot: " << (*it)->getPath() << std::endl;
+			std::cout << "\tname: " << (*it)->get_path() << std::endl;
+			std::cout << "\t\troot: " << (*it)->get_path() << std::endl;
 			if ((*it)->directory_listing_enabled() == true)
 			{
 				std::cout << "\t\tdirectory listing: enabled" << std::endl;

--- a/src/LocationInfo.cpp
+++ b/src/LocationInfo.cpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <vector>
 
-LocationInfo::LocationInfo() : _directory_listing_enabled(false), _is_cgi(false)
+LocationInfo::LocationInfo() : _autoindex(false), _directory_listing_enabled(false), _is_cgi(false)
 {
 
 }
@@ -41,14 +41,20 @@ void	LocationInfo::set_root(const std::vector <std::string>& root)
 	}
 }
 
-bool	LocationInfo::getAutoindex() const
+bool	LocationInfo::autoindex_enabled() const
 {
 	return (_autoindex);
 }
 
-void	LocationInfo::setAutoindex(bool val)
+void	LocationInfo::set_autoindex(const std::vector <std::string>& autoindex)
 {
-	_autoindex = val;
+	if (autoindex.empty() == false)
+	{
+		if (autoindex[0] == "enabled")
+		{
+			_autoindex = true;
+		}
+	}
 }
 
 std::vector <std::string>	LocationInfo::get_allowed_methods() const
@@ -170,6 +176,14 @@ std::ostream& operator<<(std::ostream& os, const LocationInfo& rhs)
 	else
 	{
 		os << "\tdirectory listing: disabled" << std::endl;
+	}
+	if (rhs.autoindex_enabled() == true)
+	{
+		os << "\tautoindex: enabled" << std::endl;
+	}
+	else
+	{
+		os << "\tautoindex: disabled" << std::endl;
 	}
 	os << "\tallowed methods: ";
 	for (size_t i = 0; i < rhs.get_allowed_methods().size(); i++)

--- a/src/LocationInfo.cpp
+++ b/src/LocationInfo.cpp
@@ -28,9 +28,9 @@ LocationInfo&	LocationInfo::operator=(const LocationInfo& rhs)
 	return (*this);
 }
 
-std::string	LocationInfo::getPath() const
+std::string	LocationInfo::get_root() const
 {
-	return (_root);
+	return _root;
 }
 
 void	LocationInfo::set_root(const std::vector <std::string>& root)
@@ -77,12 +77,12 @@ void	LocationInfo::set_directory_listing(const std::vector <std::string>& direct
 	}
 }
 
-std::string	LocationInfo::get_name() const
+std::string	LocationInfo::get_path() const
 {
 	return _name;
 }
 
-void	LocationInfo::set_name(const std::string& name)
+void	LocationInfo::set_path(const std::string& name)
 {
 	_name = name;
 }
@@ -161,8 +161,8 @@ void	LocationInfo::set_is_cgi(bool is_cgi)
 
 std::ostream& operator<<(std::ostream& os, const LocationInfo& rhs)
 {
-	os << "\troot: " << rhs.getPath() << std::endl;
-	os << "\tname: " << rhs.get_name() << std::endl;
+	os << "\troot: " << rhs.get_path() << std::endl;
+	os << "\tname: " << rhs.get_path() << std::endl;
 	if (rhs.directory_listing_enabled() == true)
 	{
 		os << "\tdirectory listing: enabled" << std::endl;

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -365,17 +365,17 @@ void	Server::get_best_location_match(std::vector<LocationInfo*> locs,
 	std::vector<LocationInfo*>::iterator it;
 	for (it = locs.begin(); it != e; it++)
 	{
-		if(rq.get_path().find((*it)->getPath()) == 0)
+		if(rq.get_path().find((*it)->get_path()) == 0)
 		{
-			if ((*it)->getPath() == "/" ||  
-			(*it)->getPath().size() == rq.get_path().size()|| 
-			rq.get_path()[(*it)->getPath().size()] == '/')
+			if ((*it)->get_path() == "/" ||  
+			(*it)->get_path().size() == rq.get_path().size()|| 
+			rq.get_path()[(*it)->get_path().size()] == '/')
 			{
-				if ((int)(*it)->getPath().size() > max_len)
+				if ((int)(*it)->get_path().size() > max_len)
 				{
 					locinfo = *it;
-					best_match = (*it)->getPath();
-					max_len = (*it)->getPath().size();
+					best_match = (*it)->get_path();
+					max_len = (*it)->get_path().size();
 				}
 			}
 		}

--- a/src/main_config.cpp
+++ b/src/main_config.cpp
@@ -7,7 +7,7 @@ int main()
 	try
 	{
 		Config conf;
-		std::cout << conf << std::endl;
+		// std::cout << conf << std::endl;
 	}
 	catch (const std::exception &e)
 	{

--- a/src/main_config.cpp
+++ b/src/main_config.cpp
@@ -7,7 +7,6 @@ int main()
 	try
 	{
 		Config conf;
-		// std::cout << conf << std::endl;
 	}
 	catch (const std::exception &e)
 	{


### PR DESCRIPTION
**changes (LocationInfo):**
* removed `get/setPath()` & `get/set_name()`
* renamed `get/setAutoIndex` to `set_autoindex()` & `autoindex_enabled()`
* adapted the `set_autoindex()` function to be more compatible with the Config

**changes (Config):**
* add parsing logic for autoindex in location blocks