### PR TITLE
Fix: Handling of client max body size

### DIFF
--- a/assets/config/simple.conf
+++ b/assets/config/simple.conf
@@ -6,7 +6,7 @@ webserv
         port                        8080;
         server_name                 domain1.com www.domain1.com localhost:8080;
         access_log                  logs/domain1.access.log;
-        client_max_body_size        100M;
+        client_max_body_size        5M;
 		index						index.html;
 		root						assets/domains/0/;
 

--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -60,8 +60,9 @@ class Config
 
 std::ostream& operator<<(std::ostream& out, const Config& config);
 
-#define CLIENT_MAX_BODY_SIZE_DEFAULT 1000000
-#define CLIENT_MAX_BODY_SIZE_MAX 10000000
+#define MEGABYTE 1048576
+#define CLIENT_MAX_BODY_SIZE_DEFAULT MEGABYTE
+#define CLIENT_MAX_BODY_SIZE_MAX (16 * MEGABYTE)
 #define MAX_URL_LENGTH 1024
 #define MAX_HEADER_LENGTH 4096
 #define ACCESS_LOG_DEFAULT "access.log"

--- a/inc/Config.hpp
+++ b/inc/Config.hpp
@@ -9,15 +9,6 @@
 #include <string>
 #include <vector>
 
-class Server;
-
-
-// Config class
-//
-// this class is responsible for the final configuration of the server
-// 
-// uses the parsed configuration file to create the ServerInfo &
-// LocationInfo objects, fill them, and to set the error pages
 class Config
 {
 	public:
@@ -58,12 +49,9 @@ class Config
 
 		std::map <int, std::string>             _error_status_codes;
 
-		// maps used to set the location and server attributes
 		location_setter_map						_location_setters;
 		server_setter_map						_server_setters;
 
-		// vector of server names
-		// used to check if a server name is unique
 		std::vector <std::string>				_server_names;
 
 		Config(const Config&) {}
@@ -73,7 +61,7 @@ class Config
 std::ostream& operator<<(std::ostream& out, const Config& config);
 
 #define CLIENT_MAX_BODY_SIZE_DEFAULT 1000000
-#define CLIENT_MAX_BODY_SIZE_MAX 100000000
+#define CLIENT_MAX_BODY_SIZE_MAX 10000000
 #define MAX_URL_LENGTH 1024
 #define MAX_HEADER_LENGTH 4096
 #define ACCESS_LOG_DEFAULT "access.log"

--- a/src/ConfigSetters.cpp
+++ b/src/ConfigSetters.cpp
@@ -145,7 +145,7 @@ namespace Setters
     {
         if (body_size_vector.empty() == true)
         {
-            Utils::config_error_on_line(-1, "no client max body size config in server '" + new_server->get_server_name()[0] + "', falling back to default (1M)\n", LOG);
+            Utils::config_error_on_line(-1, "No client max body size configured in server '" + new_server->get_server_name()[0] + "', falling back to default (1M).\n", LOG);
             new_server->set_client_max_body_size(CLIENT_MAX_BODY_SIZE_DEFAULT);
             return ;
         }
@@ -155,12 +155,12 @@ namespace Setters
 
         if (size > CLIENT_MAX_BODY_SIZE_MAX)
         {
-            Utils::config_error_on_line(-1, "client max body size too high, capping to 10M\n", LOG);
+            Utils::config_error_on_line(-1, "Client max body size too high, capping to 16M.\n", LOG);
             size = CLIENT_MAX_BODY_SIZE_MAX;
         }
         else if (size < 0)
         {
-            Utils::config_error_on_line(-1, "client max body size '" + client_max_body_size + "' is not valid, falling back to default (1M)\n", LOG);
+            Utils::config_error_on_line(-1, "Client max body size '" + client_max_body_size + "' is not valid, falling back to default (1M).\n", LOG);
             size = CLIENT_MAX_BODY_SIZE_DEFAULT;
         }
         new_server->set_client_max_body_size(size);


### PR DESCRIPTION
Client max body size was capped at 100M, which made the server vulnerable to PUT/POST spam attacks.
This is not an issue directly related to server implementation, but to excessive use of memory resources, which got the process killed by OS (same issue as /dev/urandom):

# Fix:
* Client max body size is now capped to 16M, which after some testing turned out to be the best middle ground assuring ability to upload relatively big files without overloading the hardware.

# Additional Fix:
* Client max body size was calculated in multiples of 1.000.000, which is wrong - updated to multiples of 1MB (1.048.576).
* Config was accepting any size - updated to only multiples of 2 and picking the closest value in case of mismatch (eg: 5 becomes 4, 7 becomes 8)